### PR TITLE
Change the type of the attr function so it returns Maybe instead of breaking with a javascript error when there are no selected elements.

### DIFF
--- a/src/Cheerio.js
+++ b/src/Cheerio.js
@@ -2,7 +2,13 @@ const cheerio = require('cheerio')
 
 // Attributes
 exports.attrImpl = function(nothing, just, name, cheerioInst) {
-  return cheerioInst.length ? just(cheerioInst.attr(name)) : nothing;
+
+  if (cheerioInst.length > 0) {
+    const value = cheerioInst.attr(name);
+    return value != null ? just(value) : nothing;
+  }
+
+  return nothing;
 }
 
 exports.hasClassImpl = function(className, cheerioInst) {

--- a/src/Cheerio.js
+++ b/src/Cheerio.js
@@ -1,8 +1,8 @@
 const cheerio = require('cheerio')
 
 // Attributes
-exports.attrImpl = function(name, cheerioInst) {
-  return cheerioInst.attr(name);
+exports.attrImpl = function(nothing, just, name, cheerioInst) {
+  return cheerioInst.length ? just(cheerioInst.attr(name)) : nothing;
 }
 
 exports.hasClassImpl = function(className, cheerioInst) {
@@ -48,8 +48,7 @@ exports.eqImpl = function(index, cheerioInst) {
 
 // Rendering
 exports.htmlImpl = function(nothing, just, cheerioInst) {
-  const ret = cheerioInst.html()
-  return ret != null ? just(ret) : nothing
+  return cheerioInst.length ? just(cheerioInst.html()) : nothing;
 }
 
 exports.text = function(cheerioInst) {

--- a/src/Cheerio.purs
+++ b/src/Cheerio.purs
@@ -10,7 +10,8 @@ foreign import attrImpl :: forall a.
   Fn4 (Maybe a) (a -> Maybe a) String Cheerio (Maybe String)
 
 -- | Gets an attribute value from the first selected element, returning
--- | Nothing when there are no selected elements.
+-- | Nothing when there are no selected elements, or when the first selected
+-- | element does not have the specified attribute.
 attr :: String -> Cheerio -> Maybe String
 attr = runFn4 attrImpl Nothing Just
 

--- a/src/Cheerio.purs
+++ b/src/Cheerio.purs
@@ -1,15 +1,18 @@
 module Cheerio where
 
-import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
+import Data.Function.Uncurried (Fn2, Fn3, Fn4, runFn2, runFn3, runFn4)
 import Data.Maybe (Maybe(..))
 
 foreign import data Cheerio :: Type
 
 -- Attributes
-foreign import attrImpl :: Fn2 String Cheerio String
+foreign import attrImpl :: forall a.
+  Fn4 (Maybe a) (a -> Maybe a) String Cheerio (Maybe String)
 
-attr :: String -> Cheerio -> String
-attr = runFn2 attrImpl
+-- | Gets an attribute value from the first selected element, returning
+-- | Nothing when there are no selected elements.
+attr :: String -> Cheerio -> Maybe String
+attr = runFn4 attrImpl Nothing Just
 
 foreign import hasClassImpl :: Fn2 String Cheerio Boolean
 
@@ -39,6 +42,8 @@ eq = runFn2 eqImpl
 foreign import htmlImpl :: forall a.
   Fn3 (Maybe a) (a -> Maybe a) Cheerio (Maybe String)
 
+-- | Gets an html content string from the first selected element, returning
+-- | Nothing when there are no selected elements.
 html :: Cheerio -> Maybe String
 html = runFn3 htmlImpl Nothing Just
 

--- a/test/Test/Cheerio.purs
+++ b/test/Test/Cheerio.purs
@@ -9,7 +9,8 @@ import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
 
 import Cheerio
-  ( attr
+  ( Cheerio
+  , attr
   , children
   , eq
   , find
@@ -32,13 +33,20 @@ import Test.HtmlEx (htmlEx)
 main :: Effect Unit
 main = runTest suites
 
+emptyCheerio :: Cheerio
+emptyCheerio = loadRoot htmlEx # find ".no-such-element"
+
 suites :: TestSuite
 suites = do
   suite "Attributes" do
     test "attr" do
       Assert.equal
-        "fruits"
+        (Just "fruits")
         (loadRoot htmlEx # find "ul" # attr "id")
+
+      Assert.equal
+        Nothing
+        (emptyCheerio # attr "id")
 
     test "hasClass" do
       Assert.equal
@@ -53,6 +61,10 @@ suites = do
         true
         (loadRoot htmlEx # find "li" # hasClass "pear")
 
+      Assert.equal
+        false
+        (emptyCheerio # hasClass "pear")
+
   suite "Traversing" do
     test "find" do
       Assert.equal
@@ -61,7 +73,7 @@ suites = do
 
     test "parent" do
       Assert.equal
-        "fruits"
+        (Just "fruits")
         (loadRoot htmlEx # find ".pear" # parent # attr "id")
 
     test "next" do
@@ -109,10 +121,18 @@ suites = do
         (Just "Apple")
         (loadRoot htmlEx # find ".apple" # html)
 
+      Assert.equal
+        Nothing
+        (emptyCheerio # html)
+
     test "text" do
       Assert.equal
         "Apple"
         (loadRoot htmlEx # find ".apple" # text)
+
+      Assert.equal
+        ""
+        (emptyCheerio # text)
 
   suite "More" do
     test "Long chain" do

--- a/test/Test/Cheerio.purs
+++ b/test/Test/Cheerio.purs
@@ -46,6 +46,10 @@ suites = do
 
       Assert.equal
         Nothing
+        (loadRoot htmlEx # find "ul" # attr "no-such-attribute")
+
+      Assert.equal
+        Nothing
         (emptyCheerio # attr "id")
 
     test "hasClass" do

--- a/test/Test/Cheerio/Static.purs
+++ b/test/Test/Cheerio/Static.purs
@@ -35,7 +35,7 @@ suites = do
   suite "Selectors" do
     test "select" do
       Assert.equal
-        "pear"
+        (Just "pear")
         (load htmlEx # select "ul .pear" # attr "class")
 
     test "selectDeep" do


### PR DESCRIPTION
I figured this was consistent with the type of `html` -- let me know if you want it done differently and I will revisit it (e.g. it could return an empty string when there are no selected elements).