### PR TITLE
Remove `*Impl` functions from the module interfaces.

### DIFF
--- a/src/Cheerio.purs
+++ b/src/Cheerio.purs
@@ -1,4 +1,20 @@
-module Cheerio where
+module Cheerio (
+    Cheerio,
+    attr,
+    children,
+    eq,
+    first,
+    find,
+    hasClass,
+    html,
+    last,
+    length,
+    next,
+    parent,
+    prev,
+    siblings,
+    text
+  ) where
 
 import Data.Function.Uncurried (Fn2, Fn3, Fn4, runFn2, runFn3, runFn4)
 import Data.Maybe (Maybe(..))

--- a/src/Cheerio/Static.purs
+++ b/src/Cheerio/Static.purs
@@ -1,4 +1,11 @@
-module Cheerio.Static where
+module Cheerio.Static (
+  CheerioStatic,
+  html,
+  load,
+  loadRoot,
+  select,
+  selectDeep,
+  root) where
 
 import Prelude
 import Cheerio (Cheerio)


### PR DESCRIPTION
This is more of a suggestion: it seems to me like the `*Impl` functions should not be part of the public API.